### PR TITLE
Make it work with Cocoapods use_frameworks!

### DIFF
--- a/Classes/EasyMailSender.h
+++ b/Classes/EasyMailSender.h
@@ -4,7 +4,7 @@
 
 
 #import <Foundation/Foundation.h>
-
+@import MessageUI;
 @class MFMailComposeViewController;
 
 


### PR DESCRIPTION
`MFMailComposeViewControllerDelegate` is in the `MessageUI` module and it's not imported anywhere in the header.

I added the import
